### PR TITLE
RDKE-696: Fail to activate OCDM plugin

### DIFF
--- a/OpenCDMi/OCDM.conf.in
+++ b/OpenCDMi/OCDM.conf.in
@@ -3,6 +3,7 @@ autostart = "@PLUGIN_OPENCDMI_AUTOSTART@"
 
 if boolean("@PLUGIN_OPENCDMI_PLAYREADY_NEXUS@") or \
     boolean("@PLUGIN_OPENCDMI_PLAYREADY_NEXUS_SVP@") or \
+    boolean("@PLUGIN_OPENCDMI_GENERIC@") or \
     boolean("@PLUGIN_OPENCDMI_NAGRA@") :
     precondition = ["Platform"]
 


### PR DESCRIPTION
Reason for change: For community build, change OCDM precondition from Provisioning to Platform.

Test Procedure: Check for regressions

Risks: Low

Priority: P1