### PR TITLE
RDK-57440: Causing config issue for higher versions of cmake

### DIFF
--- a/Tests/L2Tests/CMakeLists.txt
+++ b/Tests/L2Tests/CMakeLists.txt
@@ -74,8 +74,3 @@ target_include_directories(
     )
 
 install(TARGETS ${MODULE_NAME} DESTINATION lib)
-
-write_config(${PLUGIN_NAME})
-
-
-


### PR DESCRIPTION
Reason for Change: Added for CT
Test Procedure: Check for regressions
Risks: Low
Priority: P1