### PR TITLE
RDKEMW-5316 : PlayerInfo service doesn't report AV1 codec though platform supports

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -468,7 +468,8 @@ private:
             {"video/mpeg, mpegversion=(int)4, systemstream=(boolean)false", Exchange::IPlayerProperties::VideoCodec::VIDEO_MPEG4},
             {"video/x-vp8", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP8},
             {"video/x-vp9", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP9},
-            {"video/x-vp10", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP10}
+            {"video/x-vp10", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP10},
+            {"video/x-av1", Exchange::IPlayerProperties::VideoCodec::VIDEO_AV1}
         };
         if (GstUtils::GstRegistryCheckElementsForMediaTypes(videoCaps, _videoCodecs) != true) {
             TRACE(Trace::Warning, (_T("There is no Video Codec support available")));


### PR DESCRIPTION
Reason for change: To report AV1 codec from PlayerInfo service
Test Procedure: Codec support should be reported from command
Risks: No Risks
Priority: P1
Signed-off-by: pjames993@cable.comcast.com