### PR TITLE
RDKEMW-7056: Name OCDM decryption thread

### DIFF
--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -274,6 +274,9 @@ namespace Plugin {
                 private:
                     virtual uint32_t Worker() override
                     {
+                        char name [16];
+                        snprintf(name, sizeof(name), "OCDM_decrypt");
+                        prctl(PR_SET_NAME, name, 0, 0, 0);
 
                         while (IsRunning() == true) {
 


### PR DESCRIPTION
Reason for change: Enables OCDM decryption thread to be identified so that it may be prioritised if needed.
Test Procedure: Build and verify.
Risks: Low
Priority: P1