### PR TITLE
RDKEMW-8319 : Sensitive Logs are Printed in TTS plugin

### DIFF
--- a/TextToSpeech/CMakeLists.txt
+++ b/TextToSpeech/CMakeLists.txt
@@ -31,6 +31,15 @@ if(NOT WPEFRAMEWORK_SECURITYUTIL_FOUND)
     add_definitions(-DSECURITY_TOKEN_ENABLED=0)
 endif()
 
+#TTS_TEXT_LOG is used to disable unwanted logs in prod build
+if(PLUGIN_BUILD_TYPE STREQUAL "Release")
+    message(STATUS "_______________ TTS Release MODE _______________")
+    add_definitions(-DTTS_TEXT_LOG=0)
+else()
+    message(STATUS "_______________ TTS Debug MODE _______________")
+    add_definitions(-DTTS_TEXT_LOG=1)
+endif()
+
 set_source_files_properties(
         TextToSpeechImplementation.cpp
         PROPERTIES COMPILE_FLAGS "-fexceptions")

--- a/TextToSpeech/TextToSpeechImplementation.cpp
+++ b/TextToSpeech/TextToSpeechImplementation.cpp
@@ -428,7 +428,10 @@ namespace Plugin {
         if(status != TTS::TTS_OK)
             speechid = -1;
 
+#if TTS_TEXT_LOG
+        /* This log should not be present in prod builds*/
         TTSLOG_INFO("Speak invoked with text %s and speech id returned %d\n",text.c_str(),speechid);
+#endif
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
     }

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -852,7 +852,10 @@ std::string TTSSpeaker::constructURL(TTSConfiguration &config, SpeechData &d) {
           TTSLOG_INFO("re-use existing pipeline.");
        }
     }
+#if TTS_TEXT_LOG
+    /* This log should not be present in prod builds*/
     TTSLOG_WARNING("Constructed final URL is %s", tts_request.c_str());
+#endif
     return tts_request;
 }
 


### PR DESCRIPTION
 Reason for change: disabled log containing text

Test Procedure: Same as ticket
Priority: P1
Risks: None