### PR TITLE
RDKEMW-17262: disable log overflow in tts

### DIFF
--- a/SystemAudioPlayer/SystemAudioPlayer.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayer.cpp
@@ -64,7 +64,7 @@ namespace Plugin {
             #ifndef UNIT_TESTING
                 ASSERT(_connectionId != 0);
             #endif
-
+            SAPLOG_WARNING("SystemAudioPlayer::Initialize connection id %d", _connectionId);
             _sap->Configure(_service);
             _sap->Register(&_notification);
             RegisterAll();

--- a/SystemAudioPlayer/SystemAudioPlayer.h
+++ b/SystemAudioPlayer/SystemAudioPlayer.h
@@ -65,12 +65,11 @@ namespace Plugin {
 
                 virtual void Activated(RPC::IRemoteConnection* /* connection */) final
                 {
-                    SAPLOG_WARNING("SystemAudioPlayer::Notification::Activated - %p", this);
+                    /* do nothing */
                 }
 
                 virtual void Deactivated(RPC::IRemoteConnection* connection) final
                 {
-                    SAPLOG_WARNING("SystemAudioPlayer::Notification::Deactivated - %p", this);
                     _parent.Deactivated(connection);
                 }
 

--- a/TextToSpeech/TextToSpeech.cpp
+++ b/TextToSpeech/TextToSpeech.cpp
@@ -64,7 +64,7 @@ namespace Plugin {
            #ifndef UNIT_TESTING
                 ASSERT(_connectionId != 0);
            #endif
-
+            TTSLOG_WARNING("TextToSpeech::Initialize connection id %d", _connectionId);
             PluginHost::IStateControl* stateControl(_tts->QueryInterface<PluginHost::IStateControl>());
 
             if (stateControl == nullptr) {

--- a/TextToSpeech/TextToSpeech.h
+++ b/TextToSpeech/TextToSpeech.h
@@ -124,14 +124,15 @@ namespace Plugin {
                     _parent.Notify("onspeechcomplete", params);
                 }
 
-                virtual void Activated(RPC::IRemoteConnection* /* connection */) final
+                virtual void Activated(RPC::IRemoteConnection*  connection ) final
                 {
-                    TTSLOG_WARNING("TextToSpeech::Notification::Activated - %p", this);
+                    if (connection->Id() == _connectionId) {
+                         TTSLOG_WARNING("TextToSpeech::Activated - %p", this);
+                    }
                 }
 
                 virtual void Deactivated(RPC::IRemoteConnection* connection) final
                 {
-                    TTSLOG_WARNING("TextToSpeech::Notification::Deactivated - %p", this);
                     _parent.Deactivated(connection);
                 }
 

--- a/TextToSpeech/TextToSpeech.h
+++ b/TextToSpeech/TextToSpeech.h
@@ -124,7 +124,7 @@ namespace Plugin {
                     _parent.Notify("onspeechcomplete", params);
                 }
 
-                virtual void Activated(RPC::IRemoteConnection*  /* connection */ ) final
+                virtual void Activated(RPC::IRemoteConnection* /* connection */) final
                 {
                     /* do nothing */
                 }

--- a/TextToSpeech/TextToSpeech.h
+++ b/TextToSpeech/TextToSpeech.h
@@ -124,11 +124,9 @@ namespace Plugin {
                     _parent.Notify("onspeechcomplete", params);
                 }
 
-                virtual void Activated(RPC::IRemoteConnection*  connection ) final
+                virtual void Activated(RPC::IRemoteConnection*  /* connection */ ) final
                 {
-                    if (connection->Id() == _connectionId) {
-                         TTSLOG_WARNING("TextToSpeech::Activated - %p", this);
-                    }
+                    /* do nothing */
                 }
 
                 virtual void Deactivated(RPC::IRemoteConnection* connection) final


### PR DESCRIPTION
Reason for change: adding check before activation and deactivation logging
Test Procedure: Mentioned in ticket
Risks: Low
version: minor