### PR TITLE
RDKEMW-18711: Read THUNDER_ACCESS host and port via JSON Variant accessors

### DIFF
--- a/TextToSpeech/impl/NetworkStatusObserver.cpp
+++ b/TextToSpeech/impl/NetworkStatusObserver.cpp
@@ -59,9 +59,9 @@ string NetworkStatusObserver::getSecurityToken() {
             JsonObject config;
             if(config.IElement::FromFile(file)) {
                 std::string binding = config.Get("binding").String();
-                uint32_t port = config.Get("port").Number();
-                if(!binding.empty() && port != 0)
-                    endpoint = binding + ":" + std::to_string(port);
+                std::string port = config.Get("port").String();
+                if(!binding.empty() && !port.empty())
+                    endpoint = binding + ":" + port;
             }
             file.Close();
         }

--- a/TextToSpeech/impl/NetworkStatusObserver.cpp
+++ b/TextToSpeech/impl/NetworkStatusObserver.cpp
@@ -58,10 +58,10 @@ string NetworkStatusObserver::getSecurityToken() {
         if(file.Open(true)) {
             JsonObject config;
             if(config.IElement::FromFile(file)) {
-                Core::JSON::String port = config.Get("port");
-                Core::JSON::String binding = config.Get("binding");
-                if(!binding.Value().empty() && !port.Value().empty())
-                    endpoint = binding.Value() + ":" + port.Value();
+                std::string binding = config.Get("binding").String();
+                uint32_t port = config.Get("port").Number();
+                if(!binding.empty() && port != 0)
+                    endpoint = binding + ":" + std::to_string(port);
             }
             file.Close();
         }

--- a/TextToSpeech/impl/SatToken.cpp
+++ b/TextToSpeech/impl/SatToken.cpp
@@ -69,10 +69,10 @@ string SatToken::getSecurityToken() {
         if(file.Open(true)) {
             JsonObject config;
             if(config.IElement::FromFile(file)) {
-                Core::JSON::String port = config.Get("port");
-                Core::JSON::String binding = config.Get("binding");
-                if(!binding.Value().empty() && !port.Value().empty())
-                    endpoint = binding.Value() + ":" + port.Value();
+                std::string binding = config.Get("binding").String();
+                uint32_t port = config.Get("port").Number();
+                if(!binding.empty() && port != 0)
+                    endpoint = binding + ":" + std::to_string(port);
             }
             file.Close();
         }

--- a/TextToSpeech/impl/SatToken.cpp
+++ b/TextToSpeech/impl/SatToken.cpp
@@ -70,9 +70,9 @@ string SatToken::getSecurityToken() {
             JsonObject config;
             if(config.IElement::FromFile(file)) {
                 std::string binding = config.Get("binding").String();
-                uint32_t port = config.Get("port").Number();
-                if(!binding.empty() && port != 0)
-                    endpoint = binding + ":" + std::to_string(port);
+                std::string port = config.Get("port").String();
+                if(!binding.empty() && !port.empty())
+                    endpoint = binding + ":" + port;
             }
             file.Close();
         }


### PR DESCRIPTION
```
RDKEMW-18711: Read THUNDER_ACCESS host and port via JSON Variant accessors

Reason for change:
- Correct the THUNDER_ACCESS config.json fallback to parse the JSON values properly

Test Procedure: described in the ticket
Implements: code changes in TextToSpeech/impl
Risks: Low
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending

Version: patch

Signed-off-by: Sergiy Gladkyy <sgladkyy@productengine.com>
```