### PR TITLE
RDKEMW-21510: Release Cryptography Vault SecProcessor handle on deep sleep

### DIFF
--- a/Cryptography/CMakeLists.txt
+++ b/Cryptography/CMakeLists.txt
@@ -61,6 +61,9 @@ target_link_libraries(${MODULE_NAME}
         ${NAMESPACE}Cryptography::${NAMESPACE}Cryptography
 )
 
+# PowerManagerInterface.h / PluginInterfaceBuilder.h / UtilsLogging.h live in ../helpers
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+
 install(TARGETS ${MODULE_NAME}
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 

--- a/Cryptography/CryptographyExtAccess.cpp
+++ b/Cryptography/CryptographyExtAccess.cpp
@@ -18,6 +18,11 @@
  */
 
 #include "CryptographyExtAccess.h"
+#include "UtilsLogging.h"
+
+extern "C" {
+    void vault_processor_release(void);
+}
 
 namespace WPEFramework {
 namespace Plugin {
@@ -37,7 +42,7 @@ namespace Plugin {
     }
 
 
-    const string CryptographyExtAccess::Initialize(PluginHost::IShell* service) /* override */ 
+    const string CryptographyExtAccess::Initialize(PluginHost::IShell* service) /* override */
     {
         string message;
 
@@ -50,13 +55,12 @@ namespace Plugin {
         _service->AddRef();
 
         _service->Register(&_notification);
-        _implementation = _service->Root<Exchange::IConfiguration>(_connectionId, Core::infinite, _T("CryptographyImplementation"));
 
-        if (_implementation == nullptr) {
+        if (!createImplementation()) {
             message = _T("CryptographyExtAccess could not be instantiated.");
         } else {
-            printf("CryptographyExtAccess - Connection Id - %u\n",_connectionId);
-            _implementation->Configure(_service);
+            InitializePowerManager();
+            registerPowerEventHandlers();
         }
 
         return message;
@@ -67,24 +71,19 @@ namespace Plugin {
         if (_service != nullptr) {
             ASSERT(_service == service);
 
+            unregisterPowerEventHandlers();
+            DeinitializePowerManager();
+
             _service->Unregister(&_notification);
 
-            if (_implementation != nullptr) {
+            // Serialize teardown with any in-flight onPowerModeChanged().
+            // unregisterPowerEventHandlers() stops new notifications but
+            // does not wait for ones already mid-flight, which could
+            // otherwise race destroyImplementation() or use _service
+            // after we release it.
+            std::lock_guard<std::mutex> lock(_implMutex);
 
-                RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
-                printf("CryptographyExtAccess - Remote Connection  - %p\n",connection);
-
-                VARIABLE_IS_NOT_USED uint32_t result = _implementation->Release();
-                _implementation = nullptr;
-                ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
-
-                if (connection != nullptr) {
-                    TRACE(Trace::Error, (_T("CryptographyExtAccess is not properly destructed. %d"), _connectionId));
-
-                    connection->Terminate();
-                    connection->Release();
-                }
-            }
+            destroyImplementation();
 
             _connectionId = 0;
             _service->Release();
@@ -100,6 +99,12 @@ namespace Plugin {
 
     void CryptographyExtAccess::Deactivated(RPC::IRemoteConnection* connection)
     {
+        // Deep-sleep teardown intentionally drops the remote connection while
+        // _notification is still registered; ignore the resulting Deactivated
+        // so we don't submit a DEACTIVATED/FAILURE job against ourselves.
+        if (_inDeepSleep) {
+            return;
+        }
         if (connection->Id() == _connectionId) {
 
             ASSERT(_service != nullptr);
@@ -107,6 +112,109 @@ namespace Plugin {
             Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service,
                 PluginHost::IShell::DEACTIVATED,
                 PluginHost::IShell::FAILURE));
+        }
+    }
+
+    bool CryptographyExtAccess::createImplementation()
+    {
+        ASSERT(_service != nullptr);
+        ASSERT(_implementation == nullptr);
+
+        _implementation = _service->Root<Exchange::IConfiguration>(_connectionId, Core::infinite, _T("CryptographyImplementation"));
+        if (_implementation == nullptr) {
+            LOGERR("CryptographyExtAccess could not instantiate CryptographyImplementation");
+            return false;
+        }
+
+        LOGINFO("CryptographyExtAccess - Connection Id - %u", _connectionId);
+        _implementation->Configure(_service);
+        return true;
+    }
+
+    void CryptographyExtAccess::destroyImplementation()
+    {
+        if (_implementation != nullptr) {
+
+            VARIABLE_IS_NOT_USED uint32_t result = _implementation->Release();
+            _implementation = nullptr;
+            ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
+
+            // Query after Release so a non-null result means the remote
+            // genuinely failed to tear down (true error case), instead of
+            // tripping on every clean teardown including deep-sleep entry.
+            RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
+            if (connection != nullptr) {
+                TRACE(Trace::Error, (_T("CryptographyExtAccess is not properly destructed. %d"), _connectionId));
+
+                connection->Terminate();
+                connection->Release();
+            }
+        }
+    }
+
+    void CryptographyExtAccess::InitializePowerManager()
+    {
+        LOGINFO("InitializePowerManager CryptographyExtAccess");
+        _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
+            .withIShell(_service)
+            .createInterface();
+    }
+
+    void CryptographyExtAccess::DeinitializePowerManager()
+    {
+        LOGINFO("DeinitializePowerManager CryptographyExtAccess");
+        if (_powerManagerPlugin) {
+            _powerManagerPlugin.Reset();
+        }
+    }
+
+    void CryptographyExtAccess::registerPowerEventHandlers()
+    {
+        if (!_registeredPowerEventHandlers && _powerManagerPlugin) {
+            _registeredPowerEventHandlers = true;
+            _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModeChangedNotification>());
+            LOGINFO("CryptographyExtAccess registered PowerManager mode change handler");
+        } else {
+            LOGWARN("CryptographyExtAccess registerPowerEventHandlers failed");
+        }
+    }
+
+    void CryptographyExtAccess::unregisterPowerEventHandlers()
+    {
+        if (_registeredPowerEventHandlers && _powerManagerPlugin) {
+            _registeredPowerEventHandlers = false;
+            _powerManagerPlugin->Unregister(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModeChangedNotification>());
+            LOGINFO("CryptographyExtAccess unregistered PowerManager mode change handler");
+        }
+    }
+
+    void CryptographyExtAccess::onPowerModeChanged(const PowerState currentState, const PowerState newState)
+    {
+        LOGINFO("CryptographyExtAccess::onPowerModeChanged: Old State %d, New State: %d", static_cast<int>(currentState), static_cast<int>(newState));
+
+        std::lock_guard<std::mutex> lock(_implMutex);
+
+        if (newState == WPEFramework::Exchange::IPowerManager::POWER_STATE_STANDBY_DEEP_SLEEP) {
+            if (!_inDeepSleep) {
+                LOGINFO("Releasing SecAPI handle before deep sleep");
+                // Set the flag before tearing down so Deactivated(), which
+                // can fire on a worker thread when destroyImplementation()
+                // drops the remote connection, observes _inDeepSleep == true
+                // and skips the FAILURE submission.
+                _inDeepSleep = true;
+                vault_processor_release();
+                destroyImplementation();
+            }
+        } else if (_inDeepSleep) {
+            LOGINFO("Re-acquiring SecAPI handle after deep sleep");
+            if (createImplementation()) {
+                _inDeepSleep = false;
+            } else {
+                // Keep the flag set so the next non-deep-sleep transition
+                // retries createImplementation() naturally, rather than
+                // clearing state and waiting for a full sleep+wake cycle.
+                LOGERR("CryptographyExtAccess could not re-create implementation after deep sleep; will retry on next wake transition");
+            }
         }
     }
 } // namespace Plugin

--- a/Cryptography/CryptographyExtAccess.h
+++ b/Cryptography/CryptographyExtAccess.h
@@ -22,12 +22,53 @@
 #include "Module.h"
 #include <cryptography/cryptography.h>
 #include <interfaces/IConfiguration.h>
+#include <interfaces/IPowerManager.h>
+#include "PowerManagerInterface.h"
+
+#include <atomic>
+#include <mutex>
+#include <type_traits>
 
 namespace WPEFramework {
 namespace Plugin {
 
     class CryptographyExtAccess : public PluginHost::IPlugin {
     private:
+        using PowerState = Exchange::IPowerManager::PowerState;
+
+    private:
+        class PowerManagerNotification : public Exchange::IPowerManager::IModeChangedNotification {
+        private:
+            PowerManagerNotification(const PowerManagerNotification&) = delete;
+            PowerManagerNotification& operator=(const PowerManagerNotification&) = delete;
+
+        public:
+            explicit PowerManagerNotification(CryptographyExtAccess& parent)
+                : _parent(parent) {
+            }
+            ~PowerManagerNotification() override = default;
+
+        public:
+            void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
+            {
+                _parent.onPowerModeChanged(currentState, newState);
+            }
+
+            template <typename T>
+            T* baseInterface()
+            {
+                static_assert(std::is_base_of<T, PowerManagerNotification>(), "base type mismatch");
+                return static_cast<T*>(this);
+            }
+
+            BEGIN_INTERFACE_MAP(PowerManagerNotification)
+                INTERFACE_ENTRY(Exchange::IPowerManager::IModeChangedNotification)
+            END_INTERFACE_MAP
+
+        private:
+            CryptographyExtAccess& _parent;
+        };
+
         class Notification : public RPC::IRemoteConnection::INotification {
         public:
             Notification() = delete;
@@ -65,7 +106,10 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
             : _connectionId(0)
             , _service(nullptr)
             , _implementation(nullptr)
-            , _notification(*this) {
+            , _notification(*this)
+            , _pwrMgrNotification(*this)
+            , _inDeepSleep(false)
+            , _registeredPowerEventHandlers(false) {
         }
 POP_WARNING()
         ~CryptographyExtAccess() override = default;
@@ -80,15 +124,30 @@ POP_WARNING()
         const string Initialize(PluginHost::IShell* service) override;
         void Deinitialize(PluginHost::IShell* service) override;
         string Information() const override;
-    
+
     private:
         void Deactivated(RPC::IRemoteConnection* connection);
+
+        bool createImplementation();
+        void destroyImplementation();
+
+        void InitializePowerManager();
+        void DeinitializePowerManager();
+        void registerPowerEventHandlers();
+        void unregisterPowerEventHandlers();
+        void onPowerModeChanged(const PowerState currentState, const PowerState newState);
 
     private:
         uint32_t _connectionId;
         PluginHost::IShell* _service;
         Exchange::IConfiguration* _implementation;
         Core::Sink<Notification> _notification;
+
+        PowerManagerInterfaceRef _powerManagerPlugin;
+        Core::Sink<PowerManagerNotification> _pwrMgrNotification;
+        std::mutex _implMutex;
+        std::atomic<bool> _inDeepSleep;
+        bool _registeredPowerEventHandlers;
     };
 
 } // Namespace Plugin.


### PR DESCRIPTION
Reason for change:
- Backport of the RDKEMW-19048 / RDKEMW-18043 Cryptography deep-sleep handler onto `support/8.4.4.0`. On 8.4 the plugin is pre-split and lives here in entservices-mediaanddrm (`Cryptography/`), not the carved-out entservices-cryptography repo used on develop/8.6.
- `CryptographyExtAccess::onPowerModeChanged` now calls `vault_processor_release()` and `destroyImplementation()` on `POWER_STATE_STANDBY_DEEP_SLEEP`, and re-creates the implementation on the first non-deep-sleep transition after wake. Without it the SA2 SecProcessor handle at `/opt/drm/vault/` stays held across S3 and the SoC issues SOFTWARE_MASTER_RESET (RDKEMW-13788).
- Registers an `IPowerManager` `IModeChangedNotification` handler, serializes the create/destroy path with `_implMutex`, and makes `_inDeepSleep` atomic so the worker-thread `Deactivated()` observes the flag and skips the DEACTIVATED/FAILURE submission.
- Adds `../helpers` to the Cryptography plugin include path for `PowerManagerInterface.h` / `PluginInterfaceBuilder.h` / `UtilsLogging.h`; `IPowerManager` comes from the already-linked Definitions.

`vault_processor_release()` is provided by the paired clientlibraries r4.4 0002 patch backported under RDKEMW-21510.

Test Procedure: refer ticket
Risks: Low
Priority: P0
version: Patch
