### PR TITLE
RDKEMW-21038: tts crash

### DIFF
--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -796,6 +796,26 @@ void TTSSpeaker::destroyPipeline() {
     m_condition.notify_one();
 }
 
+void TTSSpeaker::gracefulShutdown() {
+    TTSLOG_WARNING("Initiating graceful shutdown...");
+    if(m_pipeline) {
+        GstState current, pending;
+        gst_element_get_state(m_pipeline, &current, &pending, 0);
+        if ((current == GST_STATE_PLAYING) && !m_isEOS && (pending != GST_STATE_NULL)) {
+            /* we should move to paused state before NULL state. It looks like souphttpsrc crashes \
+            if we move directly to NULL state while http connection is intact(RDKEMW-20138)*/
+            if (gst_element_set_state(m_pipeline, GST_STATE_PAUSED) == GST_STATE_CHANGE_ASYNC) {
+                TTSLOG_ERROR("pause transition not happening immediately");
+                waitForStatus(GST_STATE_PAUSED, 1000);
+            }
+        }
+        if (gst_element_set_state(m_pipeline, GST_STATE_NULL) == GST_STATE_CHANGE_ASYNC) {
+            TTSLOG_ERROR("null transition not happening immediately");
+            waitForStatus(GST_STATE_NULL, 1000);
+        }
+    }
+}
+
 void TTSSpeaker::waitForAudioToFinishTimeout(float timeout_s) {
     TTSLOG_TRACE("timeout_s=%f", timeout_s);
 
@@ -848,16 +868,8 @@ void TTSSpeaker::waitForAudioToFinishTimeout(float timeout_s) {
     // Irrespective of EOS / Timeout reset pipeline
     if(m_pipeline)
     {
-        GstStateChangeReturn ret = gst_element_set_state(m_pipeline, GST_STATE_NULL);
-        if(ret == GST_STATE_CHANGE_ASYNC)
-        {
-            TTSLOG_WARNING("set pipeline to NULL state in pending, waiting for completion");
-            waitForStatus(GST_STATE_NULL, 1*1000);
-        }
-        else if(ret == GST_STATE_CHANGE_FAILURE)
-            TTSLOG_ERROR("Failed to set pipeline to NULL state");
-        else if(ret == GST_STATE_CHANGE_SUCCESS)
-            TTSLOG_INFO("Pipeline set to NULL state");
+        /* Since the pipeline is stopped immediately during cancel speech we need graceful shutdown*/
+        gracefulShutdown();
     }
 
     if(!m_isEOS)

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -768,7 +768,7 @@ void TTSSpeaker::resetPipeline() {
         else if(ret == GST_STATE_CHANGE_FAILURE)
             TTSLOG_ERROR("Failed to set pipeline to NULL state");
         else if(ret == GST_STATE_CHANGE_SUCCESS)
-            TTSLOG_VERBOSE("Pipeline set to NULL state");
+            TTSLOG_INFO("Pipeline set to NULL state");
     }
 }
 
@@ -785,7 +785,7 @@ void TTSSpeaker::destroyPipeline() {
         else if(ret == GST_STATE_CHANGE_FAILURE)
             TTSLOG_ERROR("Failed to set pipeline to NULL state");
         else if(ret == GST_STATE_CHANGE_SUCCESS)
-            TTSLOG_VERBOSE("Pipeline set to NULL state");
+            TTSLOG_INFO("Pipeline set to NULL state");
         g_source_remove(m_busWatch);
         gst_object_unref(m_pipeline);
     }
@@ -857,7 +857,7 @@ void TTSSpeaker::waitForAudioToFinishTimeout(float timeout_s) {
         else if(ret == GST_STATE_CHANGE_FAILURE)
             TTSLOG_ERROR("Failed to set pipeline to NULL state");
         else if(ret == GST_STATE_CHANGE_SUCCESS)
-            TTSLOG_VERBOSE("Pipeline set to NULL state");
+            TTSLOG_INFO("Pipeline set to NULL state");
     }
 
     if(!m_isEOS)
@@ -1000,7 +1000,7 @@ void TTSSpeaker::GStreamerThreadFunc(void *ctx) {
                 else if(ret == GST_STATE_CHANGE_FAILURE)
                     TTSLOG_ERROR("Failed to set pipeline to NULL state");
                 else if(ret == GST_STATE_CHANGE_SUCCESS)
-                    TTSLOG_VERBOSE("Pipeline set to NULL state");
+                    TTSLOG_INFO("Pipeline set to NULL state");
             }
             TTSLOG_INFO("Stopping GStreamerThread");
             return;

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -759,8 +759,16 @@ void TTSSpeaker::resetPipeline() {
         createPipeline(m_pipelinetype);
     } else {
         // If pipeline is present, bring it to NULL state
-        gst_element_set_state(m_pipeline, GST_STATE_NULL);
-        while(!waitForStatus(GST_STATE_NULL, 60*1000));
+        GstStateChangeReturn ret = gst_element_set_state(m_pipeline, GST_STATE_NULL);
+        if(ret == GST_STATE_CHANGE_ASYNC)
+        {
+            TTSLOG_WARNING("set pipeline to NULL state in pending, waiting for completion");
+            while(!waitForStatus(GST_STATE_NULL, 60*1000));
+        }
+        else if(ret == GST_STATE_CHANGE_FAILURE)
+            TTSLOG_ERROR("Failed to set pipeline to NULL state");
+        else if(ret == GST_STATE_CHANGE_SUCCESS)
+            TTSLOG_VERBOSE("Pipeline set to NULL state");
     }
 }
 
@@ -768,8 +776,16 @@ void TTSSpeaker::destroyPipeline() {
     TTSLOG_WARNING("Destroying Pipeline...");
 
     if(m_pipeline) {
-        gst_element_set_state(m_pipeline, GST_STATE_NULL);
-        waitForStatus(GST_STATE_NULL, 1*1000);
+        GstStateChangeReturn ret = gst_element_set_state(m_pipeline, GST_STATE_NULL);
+        if(ret == GST_STATE_CHANGE_ASYNC)
+        {
+            TTSLOG_WARNING("set pipeline to NULL state in pending, waiting for completion");
+            waitForStatus(GST_STATE_NULL, 1*1000);
+        }
+        else if(ret == GST_STATE_CHANGE_FAILURE)
+            TTSLOG_ERROR("Failed to set pipeline to NULL state");
+        else if(ret == GST_STATE_CHANGE_SUCCESS)
+            TTSLOG_VERBOSE("Pipeline set to NULL state");
         g_source_remove(m_busWatch);
         gst_object_unref(m_pipeline);
     }
@@ -831,7 +847,18 @@ void TTSSpeaker::waitForAudioToFinishTimeout(float timeout_s) {
 
     // Irrespective of EOS / Timeout reset pipeline
     if(m_pipeline)
-        gst_element_set_state(m_pipeline, GST_STATE_NULL);
+    {
+        GstStateChangeReturn ret = gst_element_set_state(m_pipeline, GST_STATE_NULL);
+        if(ret == GST_STATE_CHANGE_ASYNC)
+        {
+            TTSLOG_WARNING("set pipeline to NULL state in pending, waiting for completion");
+            while(!waitForStatus(GST_STATE_NULL, 1*1000));
+        }
+        else if(ret == GST_STATE_CHANGE_FAILURE)
+            TTSLOG_ERROR("Failed to set pipeline to NULL state");
+        else if(ret == GST_STATE_CHANGE_SUCCESS)
+            TTSLOG_VERBOSE("Pipeline set to NULL state");
+    }
 
     if(!m_isEOS)
         TTSLOG_ERROR("Stopped waiting for audio to finish without hitting EOS!");
@@ -964,8 +991,16 @@ void TTSSpeaker::GStreamerThreadFunc(void *ctx) {
         // Stop thread on Speaker's cue
         if(!speaker->m_runThread) {
             if(speaker->m_pipeline) {
-                gst_element_set_state(speaker->m_pipeline, GST_STATE_NULL);
-                speaker->waitForStatus(GST_STATE_NULL, 1*1000);
+                GstStateChangeReturn ret = gst_element_set_state(speaker->m_pipeline, GST_STATE_NULL);
+                if(ret == GST_STATE_CHANGE_ASYNC)
+                    {
+                        TTSLOG_WARNING("set pipeline to NULL state in pending, waiting for completion");
+                        speaker->waitForStatus(GST_STATE_NULL, 1*1000);
+                    }
+                else if(ret == GST_STATE_CHANGE_FAILURE)
+                    TTSLOG_ERROR("Failed to set pipeline to NULL state");
+                else if(ret == GST_STATE_CHANGE_SUCCESS)
+                    TTSLOG_VERBOSE("Pipeline set to NULL state");
             }
             TTSLOG_INFO("Stopping GStreamerThread");
             return;

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -763,7 +763,7 @@ void TTSSpeaker::resetPipeline() {
         if(ret == GST_STATE_CHANGE_ASYNC)
         {
             TTSLOG_WARNING("set pipeline to NULL state in pending, waiting for completion");
-            while(!waitForStatus(GST_STATE_NULL, 60*1000));
+            waitForStatus(GST_STATE_NULL, 60*1000);
         }
         else if(ret == GST_STATE_CHANGE_FAILURE)
             TTSLOG_ERROR("Failed to set pipeline to NULL state");
@@ -852,7 +852,7 @@ void TTSSpeaker::waitForAudioToFinishTimeout(float timeout_s) {
         if(ret == GST_STATE_CHANGE_ASYNC)
         {
             TTSLOG_WARNING("set pipeline to NULL state in pending, waiting for completion");
-            while(!waitForStatus(GST_STATE_NULL, 1*1000));
+            waitForStatus(GST_STATE_NULL, 1*1000);
         }
         else if(ret == GST_STATE_CHANGE_FAILURE)
             TTSLOG_ERROR("Failed to set pipeline to NULL state");

--- a/TextToSpeech/impl/TTSSpeaker.h
+++ b/TextToSpeech/impl/TTSSpeaker.h
@@ -165,6 +165,7 @@ private:
     bool shouldUseLocalEndpoint();
     bool waitForStatus(GstState expected_state, uint32_t timeout_ms);
     void waitForAudioToFinishTimeout(float timeout_s);
+    void gracefulShutdown();
     bool handleMessage(GstMessage*);
     void play(string url,SpeechData &data,bool authrequired,string token);
     static int GstBusCallback(GstBus *bus, GstMessage *message, gpointer data);


### PR DESCRIPTION
Reason for change: tts crash during pipeline state transition
Test Procedure: Mentioned in ticket
Risks: Low
version: minor